### PR TITLE
fix: Deduplicate scan results by SSID, keeping the strongest RSSI (Fixes #1)

### DIFF
--- a/src/esp_wifi_manager_network.c
+++ b/src/esp_wifi_manager_network.c
@@ -356,7 +356,26 @@ esp_err_t wifi_manager_scan(wifi_scan_result_t *results, size_t max_count, size_
         results[i].rssi = ap_list[i].rssi;
         results[i].auth = ap_list[i].authmode;
     }
-    
+
+    // Deduplicate by SSID, keeping the entry with strongest RSSI
+    // This handles mesh networks and enterprise setups with multiple APs
+    for (size_t i = 0; i < copy_count; i++) {
+        for (size_t j = i + 1; j < copy_count; ) {
+            if (strcmp(results[i].ssid, results[j].ssid) == 0) {
+                // Keep stronger signal
+                if (results[j].rssi > results[i].rssi) {
+                    results[i].rssi = results[j].rssi;
+                    results[i].auth = results[j].auth;
+                }
+                // Remove duplicate by shifting remaining entries
+                memmove(&results[j], &results[j + 1], (copy_count - j - 1) * sizeof(wifi_scan_result_t));
+                copy_count--;
+            } else {
+                j++;
+            }
+        }
+    }
+
     *count = copy_count;
     free(ap_list);
     


### PR DESCRIPTION
This pull request introduces logic to deduplicate Wi-Fi scan results by SSID, ensuring that only the strongest signal for each SSID is kept. This is particularly useful in environments with mesh networks or enterprise setups where multiple access points broadcast the same SSID.

**Wi-Fi scan results deduplication:**

* Added a loop in `wifi_manager_scan` (in `src/esp_wifi_manager_network.c`) to remove duplicate SSIDs from the scan results, keeping only the entry with the strongest RSSI for each SSID. This improves scan result clarity in environments with multiple APs per SSID.