### PR TITLE
feat: Unregister portal URIs when provided httpd instance

### DIFF
--- a/src/esp_wifi_manager.c
+++ b/src/esp_wifi_manager.c
@@ -184,12 +184,16 @@ esp_err_t wifi_manager_init(const wifi_manager_config_t *config)
     if (!g_wifi_mgr->sta_netif) {
         g_wifi_mgr->sta_netif = esp_netif_create_default_wifi_sta();
         g_wifi_mgr->sta_netif_owned = true;
+    } else {
+        g_wifi_mgr->sta_netif_owned = false;
     }
     
     g_wifi_mgr->ap_netif = esp_netif_get_handle_from_ifkey("WIFI_AP_DEF");
     if (!g_wifi_mgr->ap_netif) {
         g_wifi_mgr->ap_netif = esp_netif_create_default_wifi_ap();
         g_wifi_mgr->ap_netif_owned = true;
+    } else {
+        g_wifi_mgr->ap_netif_owned = false;
     }
     
     // Init WiFi (có thể đã init bởi component khác)

--- a/src/esp_wifi_manager_http.c
+++ b/src/esp_wifi_manager_http.c
@@ -805,6 +805,8 @@ esp_err_t wifi_mgr_http_init(void)
         }
         g_wifi_mgr->httpd_owned = true;
         ESP_LOGI(TAG, "HTTP server started");
+    } else {
+        g_wifi_mgr->httpd_owned = false;
     }
     
     // Register handlers with static URI strings
@@ -909,14 +911,68 @@ esp_err_t wifi_mgr_http_init(void)
     return ESP_OK;
 }
 
+esp_err_t wifi_mgr_http_unregister_handlers(void)
+{
+    if (!g_wifi_mgr || !g_wifi_mgr->httpd) return ESP_ERR_INVALID_STATE;
+
+    httpd_handle_t httpd = g_wifi_mgr->httpd;
+
+    // Unregister API handlers initialized in wifi_mgr_http_init
+    httpd_unregister_uri_handler(httpd, uri_status, HTTP_GET);
+    httpd_unregister_uri_handler(httpd, uri_scan, HTTP_GET);
+    httpd_unregister_uri_handler(httpd, uri_networks, HTTP_GET);
+    httpd_unregister_uri_handler(httpd, uri_networks, HTTP_POST);
+    httpd_unregister_uri_handler(httpd, uri_networks_wildcard, HTTP_PUT);
+    httpd_unregister_uri_handler(httpd, uri_networks_wildcard, HTTP_DELETE);
+    httpd_unregister_uri_handler(httpd, uri_connect, HTTP_POST);
+    httpd_unregister_uri_handler(httpd, uri_disconnect, HTTP_POST);
+    httpd_unregister_uri_handler(httpd, uri_ap_status, HTTP_GET);
+    httpd_unregister_uri_handler(httpd, uri_ap_config, HTTP_GET);
+    httpd_unregister_uri_handler(httpd, uri_ap_config, HTTP_PUT);
+    httpd_unregister_uri_handler(httpd, uri_ap_start, HTTP_POST);
+    httpd_unregister_uri_handler(httpd, uri_ap_stop, HTTP_POST);
+    httpd_unregister_uri_handler(httpd, uri_vars, HTTP_GET);
+    httpd_unregister_uri_handler(httpd, uri_vars_wildcard, HTTP_PUT);
+    httpd_unregister_uri_handler(httpd, uri_vars_wildcard, HTTP_DELETE);
+    httpd_unregister_uri_handler(httpd, uri_factory_reset, HTTP_POST);
+    httpd_unregister_uri_handler(httpd, uri_options_wildcard, HTTP_OPTIONS);
+
+    // Unregister Web UI or simple page
+#ifdef CONFIG_WIFI_MGR_ENABLE_WEBUI
+    // Unregister Web UI handlers initialized in wifi_mgr_webui_init
+    httpd_unregister_uri_handler(httpd, "/", HTTP_GET);
+    httpd_unregister_uri_handler(httpd, "/assets/app.js", HTTP_GET);
+    httpd_unregister_uri_handler(httpd, "/assets/index.css", HTTP_GET);
+#else
+    httpd_unregister_uri_handler(httpd, "/", HTTP_GET);
+#endif
+
+    // Unregister captive portal detection handlers
+    if (g_wifi_mgr->config.enable_captive_portal) {
+        for (int i = 0; captive_detect_paths[i] != NULL; i++) {
+            httpd_unregister_uri_handler(httpd, captive_detect_paths[i], HTTP_GET);
+        }
+    }
+
+    ESP_LOGI(TAG, "HTTP handlers unregistered");
+    return ESP_OK;
+}
+
 esp_err_t wifi_mgr_http_deinit(void)
 {
     if (!g_wifi_mgr) return ESP_ERR_INVALID_STATE;
     
-    if (g_wifi_mgr->httpd && g_wifi_mgr->httpd_owned) {
-        httpd_stop(g_wifi_mgr->httpd);
-        g_wifi_mgr->httpd = NULL;
-        g_wifi_mgr->httpd_owned = false;
+    if (g_wifi_mgr->httpd)
+        if(g_wifi_mgr->httpd_owned) {
+            // Stop and delete httpd if we created (own) it
+            httpd_stop(g_wifi_mgr->httpd);
+            g_wifi_mgr->httpd = NULL;
+            g_wifi_mgr->httpd_owned = false;
+            ESP_LOGI(TAG, "Owned HTTP server stopped");
+        } else {
+            // Just unregister handlers if httpd not owned
+            wifi_mgr_http_unregister_handlers();
+        }
     }
     
     return ESP_OK;

--- a/src/esp_wifi_manager_http.c
+++ b/src/esp_wifi_manager_http.c
@@ -962,7 +962,7 @@ esp_err_t wifi_mgr_http_deinit(void)
 {
     if (!g_wifi_mgr) return ESP_ERR_INVALID_STATE;
     
-    if (g_wifi_mgr->httpd)
+    if (g_wifi_mgr->httpd) {
         if(g_wifi_mgr->httpd_owned) {
             // Stop and delete httpd if we created (own) it
             httpd_stop(g_wifi_mgr->httpd);

--- a/src/esp_wifi_manager_priv.h
+++ b/src/esp_wifi_manager_priv.h
@@ -155,6 +155,7 @@ esp_err_t wifi_mgr_nvs_factory_reset(void);
 // =============================================================================
 
 esp_err_t wifi_mgr_http_init(void);
+esp_err_t wifi_mgr_http_unregister_handlers(void);
 esp_err_t wifi_mgr_http_deinit(void);
 
 // =============================================================================


### PR DESCRIPTION
When the library is provided with an existing httpd instance, it registers the necessary API endpoints into that instance as part of `wifi_mgr_http_init`. When `wifi_mgr_http_deinit` is called, however, the URI handlers are only deleted if the httpd instance was created by the library as part of deleting that instance.

This creates `wifi_mgr_http_unregister_handlers` which explicitly unregisters the URIs, and calls it in `wifi_mgr_http_deinit` if the httpd instance isn't 'owned' (created by the library).