### PR TITLE
feat: Update `wifi_manager_deinit` to _optionally_ deinitialize WiFi - Breaking

### DIFF
--- a/include/esp_wifi_manager.h
+++ b/include/esp_wifi_manager.h
@@ -484,11 +484,11 @@ esp_err_t wifi_manager_init(const wifi_manager_config_t *config);
 /**
  * @brief Deinitialize WiFi Manager
  * 
- * Dừng WiFi, HTTP server và giải phóng resources.
+ * Stop the HTTP server, BLE, mDNS, and (optionally) WiFi interfaces. Free resources.
  * 
  * @return ESP_OK on success
  */
-esp_err_t wifi_manager_deinit(void);
+esp_err_t wifi_manager_deinit(bool deinit_wifi);
 
 /**
  * @brief Check if WiFi is connected

--- a/src/esp_wifi_manager.c
+++ b/src/esp_wifi_manager.c
@@ -321,7 +321,7 @@ cleanup:
     return ret;
 }
 
-esp_err_t wifi_manager_deinit(void)
+esp_err_t wifi_manager_deinit(bool deinit_wifi)
 {
     if (!g_wifi_mgr) return ESP_ERR_INVALID_STATE;
     
@@ -339,8 +339,10 @@ esp_err_t wifi_manager_deinit(void)
     esp_event_handler_unregister(WIFI_EVENT, ESP_EVENT_ANY_ID, &wifi_event_handler);
     esp_event_handler_unregister(IP_EVENT, ESP_EVENT_ANY_ID, &ip_event_handler);
     
-    esp_wifi_stop();
-    esp_wifi_deinit();
+    if (deinit_wifi) {
+        esp_wifi_stop();
+        esp_wifi_deinit();
+    }
     
     if (g_wifi_mgr->sta_netif && g_wifi_mgr->sta_netif_owned) {
         esp_netif_destroy(g_wifi_mgr->sta_netif);

--- a/src/esp_wifi_manager.c
+++ b/src/esp_wifi_manager.c
@@ -342,15 +342,18 @@ esp_err_t wifi_manager_deinit(bool deinit_wifi)
     if (deinit_wifi) {
         esp_wifi_stop();
         esp_wifi_deinit();
-    }
     
-    if (g_wifi_mgr->sta_netif && g_wifi_mgr->sta_netif_owned) {
-        esp_netif_destroy(g_wifi_mgr->sta_netif);
+        // Unless we stop the wifi, we should not destroy the netifs. If the user wants
+        // to reuse the netifs in their own code, they can reobtain the handles via
+        // esp_netif_get_handle_from_ifkey()
+        if (g_wifi_mgr->sta_netif && g_wifi_mgr->sta_netif_owned) {
+            esp_netif_destroy(g_wifi_mgr->sta_netif);
+        }
+        if (g_wifi_mgr->ap_netif && g_wifi_mgr->ap_netif_owned) {
+            esp_netif_destroy(g_wifi_mgr->ap_netif);
+        }
     }
-    if (g_wifi_mgr->ap_netif && g_wifi_mgr->ap_netif_owned) {
-        esp_netif_destroy(g_wifi_mgr->ap_netif);
-    }
-    
+        
     // Task tự delete khi nhận WM_INT_EVT_STOP, không cần delete lại
     g_wifi_mgr->task = NULL;
     vSemaphoreDelete(g_wifi_mgr->mutex);


### PR DESCRIPTION
After connecting to WiFi, I generally don't want to leave the WiFi provisioning services running, but calling `wifi_manager_deinit` also _disconnects_ WiFi, undoing what I wanted WiFi Manager to help with in the first place.

This changes the function signature of `wifi_manager_deinit` to accept a boolean signifying if `esp_wifi_stop` and `esp_wifi_deinit` should be called.

**As designed, this is a breaking change.** There are options to make it not be breaking, including C++-style defaults/overloading, or renaming the deinit function -- happy to adopt one of those styles if you prefer.