### PR TITLE
fix: Hide hidden networks during WiFi scan (Closes #13)

### DIFF
--- a/src/esp_wifi_manager_network.c
+++ b/src/esp_wifi_manager_network.c
@@ -325,7 +325,7 @@ esp_err_t wifi_manager_scan(wifi_scan_result_t *results, size_t max_count, size_
     xEventGroupClearBits(g_wifi_mgr->event_group, WIFI_SCAN_DONE_BIT);
 
     wifi_scan_config_t scan_cfg = {
-        .show_hidden = true,
+        .show_hidden = false,
     };
 
     esp_err_t ret = esp_wifi_scan_start(&scan_cfg, false);


### PR DESCRIPTION
This pull request makes a minor adjustment to the WiFi scan configuration in `src/esp_wifi_manager_network.c`. The change disables the scanning of hidden WiFi networks by setting the `.show_hidden` field to `false` instead of `true`.

This prevents hidden networks from being shown during a scan, resolving issue #13.

An alternative would be to either make this configurable (either at compile or run-time), and add logic to the SoftAP web interface (and other client documentation) explaining how to handle connecting even when no SSID is broadcast. 