### PR TITLE
feat: Variable & AP Access Callbacks, Custom UI Wildcard Support

### DIFF
--- a/include/esp_wifi_manager.h
+++ b/include/esp_wifi_manager.h
@@ -387,7 +387,7 @@ typedef struct {
  *
  * Called before every API handler (after CORS, before auth check).
  * Return ESP_OK to continue to the handler, ESP_FAIL to reject (sends 403).
- * Only applies to /api/wifi/* endpoints, not static file serving.
+ * Only applies to /api/wifi/ endpoints, not static file serving.
  */
 typedef esp_err_t (*wifi_mgr_http_hook_t)(httpd_req_t *req, void *ctx);
 

--- a/include/esp_wifi_manager.h
+++ b/include/esp_wifi_manager.h
@@ -383,6 +383,15 @@ typedef struct {
 // =============================================================================
 
 /**
+ * @brief Pre-request hook callback
+ *
+ * Called before every API handler (after CORS, before auth check).
+ * Return ESP_OK to continue to the handler, ESP_FAIL to reject (sends 403).
+ * Only applies to /api/wifi/* endpoints, not static file serving.
+ */
+typedef esp_err_t (*wifi_mgr_http_hook_t)(httpd_req_t *req, void *ctx);
+
+/**
  * @brief HTTP interface configuration
  *
  * Cấu hình HTTP REST API. Có thể dùng httpd có sẵn hoặc tạo mới.
@@ -394,6 +403,8 @@ typedef struct {
     bool enable_auth;           ///< Enable Basic Auth
     const char *auth_username;  ///< Auth username, default "admin"
     const char *auth_password;  ///< Auth password, default "admin"
+    wifi_mgr_http_hook_t pre_request_hook;  ///< Optional pre-request hook for API endpoints
+    void *hook_ctx;             ///< Context passed to pre_request_hook
 } wifi_mgr_http_config_t;
 
 /**
@@ -416,6 +427,14 @@ typedef struct {
     bool enable;                ///< Enable BLE interface
     const char *device_name;    ///< BLE device name, e.g., "ESP32-WiFi-{id}", default from Kconfig
 } wifi_mgr_ble_config_t;
+
+/**
+ * @brief Variable validation callback
+ *
+ * Called before writing a variable to NVS on PUT /api/wifi/vars/:key.
+ * Return ESP_OK to accept, ESP_FAIL to reject (API returns 400 with "var_invalid").
+ */
+typedef esp_err_t (*wifi_mgr_var_validator_t)(const char *key, const char *value, void *ctx);
 
 /**
  * @brief Main WiFi Manager configuration
@@ -446,7 +465,11 @@ typedef struct {
     bool enable_captive_portal;         ///< Start AP if all networks fail
     bool stop_ap_on_connect;            ///< Stop AP when STA connected successfully
     bool start_ap_on_init;              ///< Start AP immediately on init (AP+STA mode)
-    
+
+    // Callbacks
+    wifi_mgr_var_validator_t on_before_var_set;  ///< Optional variable validation callback
+    void *var_validator_ctx;                      ///< Context passed to on_before_var_set
+
     // Interfaces
     wifi_mgr_http_config_t http;        ///< HTTP REST API config
     wifi_mgr_mdns_config_t mdns;        ///< mDNS config

--- a/src/esp_wifi_manager_ap.c
+++ b/src/esp_wifi_manager_ap.c
@@ -187,7 +187,15 @@ esp_err_t wifi_manager_get_ap_config(wifi_mgr_ap_config_t *config)
 esp_err_t wifi_manager_set_var(const char *key, const char *value)
 {
     if (!g_wifi_mgr || !key || !value) return ESP_ERR_INVALID_ARG;
-    
+
+    // Run variable validation callback if configured
+    if (g_wifi_mgr->config.on_before_var_set) {
+        esp_err_t vret = g_wifi_mgr->config.on_before_var_set(key, value, g_wifi_mgr->config.var_validator_ctx);
+        if (vret != ESP_OK) {
+            return ESP_ERR_INVALID_ARG;
+        }
+    }
+
     wifi_mgr_lock();
     
     for (size_t i = 0; i < g_wifi_mgr->var_count; i++) {

--- a/src/esp_wifi_manager_http.c
+++ b/src/esp_wifi_manager_http.c
@@ -914,17 +914,8 @@ esp_err_t wifi_mgr_http_init(void)
     httpd_uri_t options_uri = { .uri = uri_options_wildcard, .method = HTTP_OPTIONS, .handler = handler_options };
     httpd_register_uri_handler(g_wifi_mgr->httpd, &options_uri);
 
-    // Initialize Web UI if enabled, otherwise use simple fallback page
-#ifdef CONFIG_WIFI_MGR_ENABLE_WEBUI
-    wifi_mgr_webui_init(g_wifi_mgr->httpd);
-#else
-    // Simple fallback page at root when Web UI not enabled
-    httpd_uri_t simple_uri = { .uri = "/", .method = HTTP_GET, .handler = handler_simple_page };
-    httpd_register_uri_handler(g_wifi_mgr->httpd, &simple_uri);
-    ESP_LOGI(TAG, "Simple setup page registered at /");
-#endif
-
-    // Captive portal detection handlers (for specific OS detection paths)
+    // Captive portal detection handlers - register BEFORE wildcard handlers
+    // so they take priority and aren't shadowed by "/*" wildcard matching
     if (g_wifi_mgr->config.enable_captive_portal) {
         for (int i = 0; captive_detect_paths[i] != NULL; i++) {
             httpd_uri_t captive_uri = {
@@ -936,6 +927,16 @@ esp_err_t wifi_mgr_http_init(void)
         }
         ESP_LOGI(TAG, "Captive portal detection enabled");
     }
+
+    // Initialize Web UI if enabled, otherwise use simple fallback page
+#ifdef CONFIG_WIFI_MGR_ENABLE_WEBUI
+    wifi_mgr_webui_init(g_wifi_mgr->httpd);
+#else
+    // Simple fallback page at root when Web UI not enabled
+    httpd_uri_t simple_uri = { .uri = "/", .method = HTTP_GET, .handler = handler_simple_page };
+    httpd_register_uri_handler(g_wifi_mgr->httpd, &simple_uri);
+    ESP_LOGI(TAG, "Simple setup page registered at /");
+#endif
 
     ESP_LOGI(TAG, "HTTP handlers registered");
     return ESP_OK;

--- a/src/esp_wifi_manager_http.c
+++ b/src/esp_wifi_manager_http.c
@@ -638,18 +638,13 @@ static esp_err_t handler_put_var(httpd_req_t *req)
         return send_error(req, 400, "Missing value");
     }
 
-    // Run variable validation callback if configured
-    if (g_wifi_mgr->config.on_before_var_set) {
-        esp_err_t vret = g_wifi_mgr->config.on_before_var_set(key, value->valuestring, g_wifi_mgr->config.var_validator_ctx);
-        if (vret != ESP_OK) {
-            cJSON_Delete(json);
-            return send_error(req, 400, "var_invalid");
-        }
-    }
-    
-    wifi_manager_set_var(key, value->valuestring);
+    esp_err_t set_ret = wifi_manager_set_var(key, value->valuestring);
     cJSON_Delete(json);
-    
+
+    if (set_ret != ESP_OK) {
+        return send_error(req, 400, "var_invalid");
+    }
+
     return send_ok(req);
 }
 

--- a/src/esp_wifi_manager_http.c
+++ b/src/esp_wifi_manager_http.c
@@ -100,6 +100,7 @@ static esp_err_t send_error(httpd_req_t *req, int code, const char *msg)
     switch (code) {
         case 400: status = "400 Bad Request"; break;
         case 401: status = "401 Unauthorized"; break;
+        case 403: status = "403 Forbidden"; break;
         case 404: status = "404 Not Found"; break;
         case 500: status = "500 Internal Server Error"; break;
         default:  status = "400 Bad Request"; break;
@@ -112,6 +113,33 @@ static esp_err_t send_error(httpd_req_t *req, int code, const char *msg)
     snprintf(buf, sizeof(buf), "{\"error\":\"%s\"}", msg);
     httpd_resp_sendstr(req, buf);
     return ESP_FAIL;
+}
+
+/**
+ * @brief Run pre-request hook and auth check for API handlers
+ *
+ * Calls the pre-request hook first (if configured), then the built-in auth check.
+ * Returns true if the request should proceed, false if rejected.
+ * On rejection, the appropriate error response has already been sent.
+ */
+static bool check_api_access(httpd_req_t *req)
+{
+    // Pre-request hook (called before auth, so hook can replace/supplement auth)
+    if (g_wifi_mgr->config.http.pre_request_hook) {
+        esp_err_t hook_ret = g_wifi_mgr->config.http.pre_request_hook(req, g_wifi_mgr->config.http.hook_ctx);
+        if (hook_ret != ESP_OK) {
+            send_error(req, 403, "Forbidden");
+            return false;
+        }
+    }
+
+    // Built-in auth check
+    if (!check_auth(req)) {
+        send_error(req, 401, "Unauthorized");
+        return false;
+    }
+
+    return true;
 }
 
 /**
@@ -153,8 +181,8 @@ static cJSON *read_json_body(httpd_req_t *req)
 // GET /status
 static esp_err_t handler_get_status(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     wifi_status_t status;
@@ -185,8 +213,8 @@ static esp_err_t handler_get_status(httpd_req_t *req)
 // GET /scan
 static esp_err_t handler_get_scan(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     wifi_scan_result_t results[20];
@@ -227,8 +255,8 @@ static esp_err_t handler_get_scan(httpd_req_t *req)
 // GET /networks
 static esp_err_t handler_get_networks(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     wifi_network_t networks[WIFI_MGR_MAX_NETWORKS];
@@ -253,8 +281,8 @@ static esp_err_t handler_get_networks(httpd_req_t *req)
 // POST /networks
 static esp_err_t handler_post_networks(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     cJSON *json = read_json_body(req);
@@ -293,8 +321,8 @@ static esp_err_t handler_post_networks(httpd_req_t *req)
 // DELETE /networks/:ssid
 static esp_err_t handler_delete_network(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     // Extract SSID from URI
@@ -320,8 +348,8 @@ static esp_err_t handler_delete_network(httpd_req_t *req)
 // PUT /networks/:ssid - Update network (password, priority)
 static esp_err_t handler_put_network(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     // Extract SSID from URI
@@ -370,8 +398,8 @@ static esp_err_t handler_put_network(httpd_req_t *req)
 // POST /connect
 static esp_err_t handler_post_connect(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     if (req->content_len > 0) {
@@ -394,8 +422,8 @@ static esp_err_t handler_post_connect(httpd_req_t *req)
 // POST /disconnect
 static esp_err_t handler_post_disconnect(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     wifi_manager_disconnect();
@@ -405,8 +433,8 @@ static esp_err_t handler_post_disconnect(httpd_req_t *req)
 // GET /ap/status
 static esp_err_t handler_get_ap_status(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     wifi_ap_status_t status;
@@ -435,8 +463,8 @@ static esp_err_t handler_get_ap_status(httpd_req_t *req)
 // GET /ap/config
 static esp_err_t handler_get_ap_config(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     wifi_mgr_ap_config_t config;
@@ -462,8 +490,8 @@ static esp_err_t handler_get_ap_config(httpd_req_t *req)
 // PUT /ap/config
 static esp_err_t handler_put_ap_config(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     cJSON *json = read_json_body(req);
@@ -515,8 +543,8 @@ static esp_err_t handler_put_ap_config(httpd_req_t *req)
 // POST /ap/start
 static esp_err_t handler_post_ap_start(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     wifi_mgr_ap_config_t *config = NULL;
@@ -546,8 +574,8 @@ static esp_err_t handler_post_ap_start(httpd_req_t *req)
 // POST /ap/stop
 static esp_err_t handler_post_ap_stop(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     wifi_manager_stop_ap();
@@ -557,8 +585,8 @@ static esp_err_t handler_post_ap_stop(httpd_req_t *req)
 // GET /vars
 static esp_err_t handler_get_vars(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     wifi_mgr_lock();
@@ -583,8 +611,8 @@ static esp_err_t handler_get_vars(httpd_req_t *req)
 // PUT /vars/:key
 static esp_err_t handler_put_var(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
     
     // Extract key from URI
@@ -609,6 +637,15 @@ static esp_err_t handler_put_var(httpd_req_t *req)
         cJSON_Delete(json);
         return send_error(req, 400, "Missing value");
     }
+
+    // Run variable validation callback if configured
+    if (g_wifi_mgr->config.on_before_var_set) {
+        esp_err_t vret = g_wifi_mgr->config.on_before_var_set(key, value->valuestring, g_wifi_mgr->config.var_validator_ctx);
+        if (vret != ESP_OK) {
+            cJSON_Delete(json);
+            return send_error(req, 400, "var_invalid");
+        }
+    }
     
     wifi_manager_set_var(key, value->valuestring);
     cJSON_Delete(json);
@@ -619,8 +656,8 @@ static esp_err_t handler_put_var(httpd_req_t *req)
 // DELETE /vars/:key
 static esp_err_t handler_delete_var(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
 
     // Extract key from URI
@@ -646,8 +683,8 @@ static esp_err_t handler_delete_var(httpd_req_t *req)
 // POST /factory_reset
 static esp_err_t handler_post_factory_reset(httpd_req_t *req)
 {
-    if (!check_auth(req)) {
-        return send_error(req, 401, "Unauthorized");
+    if (!check_api_access(req)) {
+        return ESP_FAIL;
     }
 
     esp_err_t ret = wifi_manager_factory_reset();

--- a/src/esp_wifi_manager_webui.c
+++ b/src/esp_wifi_manager_webui.c
@@ -22,13 +22,49 @@ extern const uint8_t index_css_gz_start[] asm("_binary_index_css_gz_start");
 extern const uint8_t index_css_gz_end[] asm("_binary_index_css_gz_end");
 
 /**
- * @brief Try to serve file from custom path (SPIFFS/LittleFS)
+ * @brief Get the filesystem base path for custom WebUI files
+ *
+ * Returns the CONFIG_WIFI_MGR_WEBUI_CUSTOM_PATH if set, NULL otherwise.
+ */
+static const char *get_fs_base_path(void)
+{
+#ifdef CONFIG_WIFI_MGR_WEBUI_CUSTOM_PATH
+    const char *path = CONFIG_WIFI_MGR_WEBUI_CUSTOM_PATH;
+    if (path && path[0]) {
+        return path;
+    }
+#endif
+    return NULL;
+}
+
+/**
+ * @brief Determine MIME content type from file path
+ */
+static const char *get_content_type(const char *filepath)
+{
+    if (strstr(filepath, ".html")) return "text/html";
+    if (strstr(filepath, ".js"))   return "application/javascript";
+    if (strstr(filepath, ".css"))  return "text/css";
+    if (strstr(filepath, ".json")) return "application/json";
+    if (strstr(filepath, ".png"))  return "image/png";
+    if (strstr(filepath, ".svg"))  return "image/svg+xml";
+    if (strstr(filepath, ".ico"))  return "image/x-icon";
+    if (strstr(filepath, ".jpg") || strstr(filepath, ".jpeg")) return "image/jpeg";
+    if (strstr(filepath, ".woff2")) return "font/woff2";
+    if (strstr(filepath, ".woff")) return "font/woff";
+    if (strstr(filepath, ".ttf"))  return "font/ttf";
+    if (strstr(filepath, ".gif"))  return "image/gif";
+    if (strstr(filepath, ".webp")) return "image/webp";
+    return "text/plain";
+}
+
+/**
+ * @brief Try to serve file from custom filesystem path (SPIFFS/LittleFS)
  */
 static bool serve_from_filesystem(httpd_req_t *req, const char *filepath)
 {
-#ifdef CONFIG_WIFI_MGR_WEBUI_CUSTOM_PATH
-    const char *base_path = CONFIG_WIFI_MGR_WEBUI_CUSTOM_PATH;
-    if (!base_path || !base_path[0]) {
+    const char *base_path = get_fs_base_path();
+    if (!base_path) {
         return false;
     }
 
@@ -46,23 +82,7 @@ static bool serve_from_filesystem(httpd_req_t *req, const char *filepath)
         return false;
     }
 
-    // Determine content type
-    const char *content_type = "text/plain";
-    if (strstr(filepath, ".html")) {
-        content_type = "text/html";
-    } else if (strstr(filepath, ".js")) {
-        content_type = "application/javascript";
-    } else if (strstr(filepath, ".css")) {
-        content_type = "text/css";
-    } else if (strstr(filepath, ".json")) {
-        content_type = "application/json";
-    } else if (strstr(filepath, ".png")) {
-        content_type = "image/png";
-    } else if (strstr(filepath, ".svg")) {
-        content_type = "image/svg+xml";
-    }
-
-    httpd_resp_set_type(req, content_type);
+    httpd_resp_set_type(req, get_content_type(filepath));
 
     // Check for gzipped version
     char gzpath[132];
@@ -86,9 +106,6 @@ static bool serve_from_filesystem(httpd_req_t *req, const char *filepath)
     fclose(f);
     ESP_LOGD(TAG, "Served from filesystem: %s", filepath);
     return true;
-#else
-    return false;
-#endif
 }
 
 /**
@@ -147,6 +164,24 @@ static esp_err_t handler_webui_index_css(httpd_req_t *req)
 }
 
 /**
+ * @brief Wildcard handler for additional static files from filesystem
+ *
+ * Serves any file found on the configured filesystem path that doesn't
+ * match the explicit handlers (index, app.js, index.css). Returns 404
+ * if the file doesn't exist on the filesystem.
+ */
+static esp_err_t handler_webui_wildcard(httpd_req_t *req)
+{
+    // req->uri is the file path (e.g., "/assets/logo.png")
+    if (serve_from_filesystem(req, req->uri)) {
+        return ESP_OK;
+    }
+
+    httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, NULL);
+    return ESP_FAIL;
+}
+
+/**
  * @brief Initialize Web UI handlers
  */
 esp_err_t wifi_mgr_webui_init(httpd_handle_t httpd)
@@ -155,9 +190,11 @@ esp_err_t wifi_mgr_webui_init(httpd_handle_t httpd)
         return ESP_ERR_INVALID_ARG;
     }
 
-    ESP_LOGI(TAG, "Initializing Web UI");
+    const char *fs_path = get_fs_base_path();
 
-    // Register handlers
+    ESP_LOGI(TAG, "Initializing Web UI (fs_path: %s)", fs_path ? fs_path : "(embedded only)");
+
+    // Register explicit handlers for known files
     httpd_uri_t index_uri = {
         .uri = "/",
         .method = HTTP_GET,
@@ -178,6 +215,17 @@ esp_err_t wifi_mgr_webui_init(httpd_handle_t httpd)
         .handler = handler_webui_index_css,
     };
     httpd_register_uri_handler(httpd, &css_uri);
+
+    // Register wildcard handler for additional static files from filesystem
+    if (fs_path) {
+        httpd_uri_t wildcard_uri = {
+            .uri = "/*",
+            .method = HTTP_GET,
+            .handler = handler_webui_wildcard,
+        };
+        httpd_register_uri_handler(httpd, &wildcard_uri);
+        ESP_LOGI(TAG, "Wildcard file serving enabled from %s", fs_path);
+    }
 
     size_t total_size = (index_html_end - index_html_start) +
                         (app_js_gz_end - app_js_gz_start) +


### PR DESCRIPTION
This pull request introduces new extensibility points and improves the flexibility and maintainability of the WiFi manager's HTTP API and Web UI file serving. The most important changes include adding pre-request and variable validation hooks for API endpoints, centralizing access control logic, and enhancing static file serving from the filesystem.

**API extensibility and security:**

* Added a `pre_request_hook` callback to `wifi_mgr_http_config_t`, allowing custom logic to run before each API handler (after CORS, before authentication). If the hook returns failure, the request is rejected with a 403 error.
* Added a variable validation hook (`on_before_var_set`) to `wifi_mgr_config_t`, which allows custom validation logic before accepting changes to variables via the API. If validation fails, the API returns a 400 error with a "var_invalid" message.

The `pre_request_hook` callback is designed to allow extending the web interface -- for example, allowing a user to build more robust authentication into his/her firmware before enabling the HTTP endpoints to be accessed/used. This is implemented as a callback rather than using `esp_bus` as the function is intended to enable interrupting the message 

The `on_before_var_set` callback is intended to allow validation of a variable's value prior to it being set/saved. For example, I plan to use a variable to let the user set an mDNS name for his/her device as part of the WiFI connection workflow. This allows me to reject setting the variable if it doesn't pass validation rules I set in the callback. Again, this is implemented as a callback rather than using `esp_bus` as the function is intended to enable interrupting the saving of the variable if the criteria are not met.


**HTTP handler refactoring:**

* Centralized access control logic by introducing a `check_api_access` function, which runs the pre-request hook and authentication check for each API endpoint, reducing code duplication and improving maintainability.
* Added support for sending 403 Forbidden errors from API handlers.


**Web UI static file serving improvements:**

* Refactored static file serving to use a new `get_fs_base_path` helper, and added a `get_content_type` function for determining MIME types. This improves maintainability and extensibility for serving custom files.
* Introduced a wildcard handler to serve any additional static files found on the configured filesystem path, enabling flexible Web UI customization. 

These changes enable a user to further extend a custom web UI with files we don't have an explicit handler set up for when setting `CONFIG_WIFI_MGR_ENABLE_WEBUI` - for example, images, additional stylesheets, etc.


**Two things to note here:** 
1. This additional (wildcard) path will need to be deinitialized/unregistered along with the explicitly set wildcard paths [here](https://github.com/tuanpmt/esp_wifi_manager/pull/6/changes#diff-10086e36f7993b5ab24578f64eb6b1bbf34b76277d5bd6bf7b7c615a216c096fR941-R946) when #6 is merged
2. There is a _potential_ security issue here if the user saves sensitive information to his/her LittleFS filesystem in the same folder as the WiFi Manager WebUI, as the wildcard path will enable every file (including those sensitive files) to be served publicly. One way to mitigate this would be to define-gate enabling the wildcard handler only if the user specifies `CONFIG_WIFI_MGR_WEBUI_CUSTOM_PATH` - but this would add complexity for users who only use the filesystem for hosting the custom WiFi Manager UI -- and feels like an edge case, as any user who is editing a device's network info likely should have full access to the device contents anyways. The more crucial fix here is to deregister this wildcard endpoint. 
