### PR TITLE
fix: Prevent sending two start_ap (and one erroneous stop_ap) messages

### DIFF
--- a/src/esp_wifi_manager.c
+++ b/src/esp_wifi_manager.c
@@ -552,7 +552,9 @@ static void wifi_mgr_task(void *arg)
                     
                 case WM_INT_EVT_AP_STARTED:
                     g_wifi_mgr->ap_active = true;
-                    esp_bus_emit(WIFI_MODULE, WIFI_MGR_EVT_AP_START, NULL, 0);
+                    // esp_bus event is emitted from wifi_manager_start_ap() after
+                    // config is fully applied, not here (avoids double events from
+                    // intermediate driver restarts)
                     break;
                     
                 case WM_INT_EVT_AP_STOPPED:

--- a/src/esp_wifi_manager.c
+++ b/src/esp_wifi_manager.c
@@ -559,7 +559,7 @@ static void wifi_mgr_task(void *arg)
                     
                 case WM_INT_EVT_AP_STOPPED:
                     g_wifi_mgr->ap_active = false;
-                    esp_bus_emit(WIFI_MODULE, WIFI_MGR_EVT_AP_STOP, NULL, 0);
+                    // esp_bus event is emitted from wifi_manager_stop_ap()
                     break;
                     
                 case WM_INT_EVT_AP_STA_CONN:

--- a/src/esp_wifi_manager_ap.c
+++ b/src/esp_wifi_manager_ap.c
@@ -97,7 +97,12 @@ esp_err_t wifi_manager_start_ap(const wifi_mgr_ap_config_t *config)
         esp_netif_set_ip_info(g_wifi_mgr->ap_netif, &ip_info);
         esp_netif_dhcps_start(g_wifi_mgr->ap_netif);
     }
-    
+
+    // Emit AP start event after config is fully applied, so listeners
+    // see the correct SSID/IP. This avoids spurious events from
+    // intermediate driver restarts (set_mode then set_config).
+    esp_bus_emit(WIFI_MODULE, WIFI_MGR_EVT_AP_START, NULL, 0);
+
     return ESP_OK;
 }
 

--- a/src/esp_wifi_manager_ap.c
+++ b/src/esp_wifi_manager_ap.c
@@ -118,6 +118,8 @@ esp_err_t wifi_manager_stop_ap(void)
     g_wifi_mgr->ap_active = false;
     esp_wifi_set_mode(WIFI_MODE_STA);
 
+    esp_bus_emit(WIFI_MODULE, WIFI_MGR_EVT_AP_STOP, NULL, 0);
+
     return ESP_OK;
 }
 


### PR DESCRIPTION
As originally discussed in #5, when using the Soft AP + Captive Portal configuration method, one thing I noticed in the logs is that the AP gets started twice:

```
I (10167) wifi_mgr: WiFi Manager initialized, 0 networks configured
I (10168) wifi_mgr: AP started
I (10169) wifi_mgr: AP stopped
I (10173) wifi_mgr: AP started
```

Although this is accurate as to what is happening behind the scenes, users that hook the `WIFI_MGR_EVT_AP_START` and `WIFI_MGR_EVT_AP_STOP` events likely don't care about the first start/stop as they're almost instantaneous as the configuration is being updated.

This change moves emitting these events to the relevant `esp_wifi_manager` functions.

Although this could technically be construed as a breaking change, I can't think of an implementation where the previous behavior would be desired, so I would suggest it's worth making regardless.